### PR TITLE
Fixed options to ACTUALLY be optional.

### DIFF
--- a/api/ConvertOptions.ts
+++ b/api/ConvertOptions.ts
@@ -1,10 +1,10 @@
 import OcrSettings from "./OcrSettings";
 
 interface ConvertOptions {
-  fileName: string | undefined;
-  callbackUrl: string | undefined;
-  ocrEnabled: boolean | undefined;
-  ocrSettings: OcrSettings | undefined;
+  fileName?: string;
+  callbackUrl?: string;
+  ocrEnabled?: boolean;
+  ocrSettings?: OcrSettings;
 }
 
 export default ConvertOptions;


### PR DESCRIPTION
I was experiencing an issue where Typescript expected all keys in the options object when that object existed. For example:
```ts
imgApi.convertFromBuffer(imgBuffer, "png", {
    callbackUrl: "",
    fileName: "skin.dds"
})```

This would throw a TS error on the object, expecting the other field names.